### PR TITLE
Support dark theme throughout the App

### DIFF
--- a/lib/ui/pages/cities_page.dart
+++ b/lib/ui/pages/cities_page.dart
@@ -5,11 +5,13 @@ import 'package:covidtracker/ui/widgets/dark_background.dart';
 import 'package:covidtracker/ui/widgets/home_appbar.dart';
 import 'package:covidtracker/ui/widgets/world_loading.dart';
 import 'package:covidtracker/utils/assets_utils.dart';
+import 'package:covidtracker/utils/decoration_utils.dart';
 import 'package:flutter/material.dart';
 
 class CitiesPage extends StatelessWidget {
   API _api = API.getInstance();
   BuildContext context;
+  DecorationUtils _decorationUtils = DecorationUtils.getInstance();
 
   @override
   Widget build(BuildContext context) {
@@ -39,22 +41,38 @@ class CitiesPage extends StatelessWidget {
   Widget _buildListOfCities(List<RegionInfo> list) {
     list.sort((a, b) => -(a.cases - b.cases));
 
-    return ListView.builder(
+    return GridView.builder(
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 8,
+        mainAxisSpacing: 8,
+      ),
       itemCount: list.length,
       itemBuilder: (context, index) {
         String name = list[index].name;
         String cases = list[index].cases.toString();
         return Card(
-          elevation: 2,
+          shape: _decorationUtils.getCardRoundedBorder(12),
+          color: Colors.black.withOpacity(0.2),
+          elevation: 3,
           margin: EdgeInsets.all(8),
-          child: ListTile(
-            leading: CircleAvatar(
-              backgroundImage:
-                  AssetImage(AssetsUtils.getInstance().getJPGImagePath(name)),
-              radius: 30,
-            ),
-            title: Text(AppLocale.getUnknownString(context, list[index].name)),
-            subtitle: Text(cases),
+          child: Column(
+            children: <Widget>[
+              Expanded(
+                child: _decorationUtils.clipTopWithRadius(
+                  Image.asset(
+                    AssetsUtils.getInstance().getJPGImagePath(name),
+                    fit: BoxFit.cover,
+                  ),
+                  12,
+                ),
+              ),
+              Text(
+                AppLocale.getUnknownString(context, list[index].name),
+                style: TextStyle(color: Colors.white, fontSize: 14),
+              ),
+              Text(cases, style: TextStyle(color: Colors.white)),
+            ],
           ),
         );
       },

--- a/lib/ui/widgets/charts/active_cases.dart
+++ b/lib/ui/widgets/charts/active_cases.dart
@@ -1,4 +1,5 @@
 import 'package:covidtracker/models/chart_data_model.dart';
+import 'package:covidtracker/utils/decoration_utils.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
@@ -8,13 +9,15 @@ class ActiveCases extends StatelessWidget {
     const Color(0xff7ea1f8),
   ];
   List<ChartDataModel> dataList;
+  DecorationUtils _decorationUtils = DecorationUtils.getInstance();
 
   ActiveCases({@required this.dataList});
 
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: Colors.white,
+      shape: _decorationUtils.getCardRoundedBorder(12),
+      color: Colors.black.withOpacity(0.2),
       margin: EdgeInsets.all(8),
       child: AspectRatio(
         aspectRatio: 1.5,
@@ -58,9 +61,9 @@ class ActiveCases extends StatelessWidget {
         showTitles: true,
         reservedSize: 22,
         textStyle: const TextStyle(
-            color: Colors.black, fontWeight: FontWeight.bold, fontSize: 16),
+            color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
         getTitles: (value) {
-          if (value == dataList.length.ceil() / 2) return 'Active cases';
+          if (value == (dataList.length / 2).ceil()) return 'Active cases';
           return '';
         },
         margin: 8,
@@ -68,13 +71,13 @@ class ActiveCases extends StatelessWidget {
       leftTitles: SideTitles(
         showTitles: true,
         textStyle: const TextStyle(
-          color: Colors.black,
+          color: Colors.white,
           fontWeight: FontWeight.bold,
           fontSize: 15,
         ),
         getTitles: (value) {
-          if (value == 0) return '0';
-          if (value == _maxY) return '${_maxY.toInt()}';
+          if (value <= _maxY && value % 50 == 0)
+            return value.toInt().toString();
           return '';
         },
         reservedSize: 28,

--- a/lib/ui/widgets/charts/daily_cases.dart
+++ b/lib/ui/widgets/charts/daily_cases.dart
@@ -1,24 +1,26 @@
 import 'package:covidtracker/lang/locale.dart';
 import 'package:covidtracker/models/chart_data_model.dart';
+import 'package:covidtracker/utils/decoration_utils.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class DailyCases extends StatelessWidget {
   List<ChartDataModel> dataList;
+  DecorationUtils _decorationUtils = DecorationUtils.getInstance();
 
   DailyCases({@required this.dataList});
 
   BuildContext context;
   List<BarChartRodData> _list;
   double _maxY;
-  int _maxX;
 
   @override
   Widget build(BuildContext context) {
     this.context = context;
     getData();
     return Card(
-      color: Colors.white,
+      shape: _decorationUtils.getCardRoundedBorder(12),
+      color: Colors.black.withOpacity(0.2),
       margin: EdgeInsets.all(8),
       child: AspectRatio(
         aspectRatio: 1.5,
@@ -38,7 +40,7 @@ class DailyCases extends StatelessWidget {
               bottomTitles: SideTitles(
                 showTitles: true,
                 textStyle: TextStyle(
-                  color: Colors.black,
+                  color: Colors.white,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -50,8 +52,13 @@ class DailyCases extends StatelessWidget {
               leftTitles: SideTitles(showTitles: false),
             ),
             borderData: FlBorderData(
-              show: true,
-            ),
+                show: true,
+                border: Border(
+                  bottom: BorderSide(
+                    color: Colors.white.withOpacity(.8),
+                    width: 2,
+                  ),
+                )),
             barGroups: [
               BarChartGroupData(
                 x: 0,
@@ -72,8 +79,9 @@ class DailyCases extends StatelessWidget {
       getTooltipItem: (_, __, rod, index) {
         int val = rod.y.round();
         return BarTooltipItem(
-            '$val in ${dataList[index].date.substring(5).replaceAll('-', '/')}',
-            TextStyle(color: Colors.white));
+          '$val in ${dataList[index].date.substring(5).replaceAll('-', '/')}',
+          TextStyle(color: Colors.white, fontSize: 16),
+        );
       },
     );
   }
@@ -81,9 +89,11 @@ class DailyCases extends StatelessWidget {
   void getData() {
     _list = [];
     _maxY = 0;
-    _maxX = 0;
-    for (int i = 0; i < dataList.length; i++) {
-      _maxX++;
+    int maxNumberOfItems = 80;
+    int start = dataList.length <= maxNumberOfItems
+        ? 0
+        : dataList.length - maxNumberOfItems;
+    for (int i = start; i < dataList.length; i++) {
       double val = dataList[i].active - (i == 0 ? 0 : dataList[i - 1].active);
       // Get abs value
       if (val < 0) val *= -1;
@@ -93,7 +103,7 @@ class DailyCases extends StatelessWidget {
       _list.add(
         BarChartRodData(
           y: val,
-          color: Colors.blueAccent,
+          color: Color(0xff6ecff5),
           width: 4,
         ),
       );

--- a/lib/ui/widgets/charts/summary_chart.dart
+++ b/lib/ui/widgets/charts/summary_chart.dart
@@ -1,6 +1,7 @@
 import 'package:covidtracker/lang/locale.dart';
 import 'package:covidtracker/models/summary_model.dart';
 import 'package:covidtracker/repo/api.dart';
+import 'package:covidtracker/utils/decoration_utils.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
@@ -13,6 +14,7 @@ class SummaryChartState extends State {
   int _touchedIndex;
   double _active = 100, _recovered = 0, _lost = 0;
   API _api = API.getInstance();
+  DecorationUtils _decorationUtils = DecorationUtils.getInstance();
 
   @override
   Widget build(BuildContext context) {
@@ -20,8 +22,9 @@ class SummaryChartState extends State {
     return AspectRatio(
       aspectRatio: 1.5,
       child: Card(
+        shape: _decorationUtils.getCardRoundedBorder(12),
+        color: Colors.black.withOpacity(0.2),
         margin: EdgeInsets.all(8),
-        color: Colors.white,
         child: Row(
           children: <Widget>[
             const SizedBox(height: 18),
@@ -69,11 +72,11 @@ class SummaryChartState extends State {
         ),
         Text(
           AppLocale.getString(context, 'recovered'),
-          style: TextStyle(fontSize: 18, color: Color(0xff62a340)),
+          style: TextStyle(fontSize: 18, color: Color(0xff9bde78)),
         ),
         Text(
           AppLocale.getString(context, 'lost'),
-          style: TextStyle(fontSize: 18, color: Color(0xffd05a81)),
+          style: TextStyle(fontSize: 18, color: Colors.red),
         ),
         SizedBox(height: 40),
       ],
@@ -143,7 +146,7 @@ class SummaryChartState extends State {
         // Lost
         case 2:
           return PieChartSectionData(
-            color: const Color(0xffd05a81),
+            color: Colors.red,
             value: _lost,
             title: '$lostString%',
             radius: radius,


### PR DESCRIPTION
- Support dark theme for the statistics and cities pages.
- Use Grid (2 cols) instead of Listview in the cities page.